### PR TITLE
[FIX] Export issue

### DIFF
--- a/src/main/java/at/impro/wordclockgenerator/JPGraphToMatrix.java
+++ b/src/main/java/at/impro/wordclockgenerator/JPGraphToMatrix.java
@@ -237,7 +237,7 @@ public class JPGraphToMatrix extends javax.swing.JPanel {
     private void jBExportActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jBExportActionPerformed
         final JFileChooser fc = new JFileChooser();
         fc.showSaveDialog(this);
-        String ln=java.security.AccessController.doPrivileged(new sun.security.action.GetPropertyAction("line.separator"));
+        String ln= System.lineSeparator();
         try (Writer file = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(fc.getSelectedFile()), "utf-8"))) {
             int lh=resultmatrix.length;
             int lw=resultmatrix[0].length;


### PR DESCRIPTION
Due to the export issue, the line separator has been changed to `System.lineSeparator()`.
```
Exception in thread "AWT-EventQueue-0" java.lang.IllegalAccessError:
class at.impro.wordclockgenerator.JPGraphToMatrix (in unnamed module
@0x8504151) cannot access class
sun.security.action.GetPropertyAction (in module java.base) because
module java.base does not export sun.security.action to unnamed module
@0x8504151
```